### PR TITLE
Bump submodule to latest commit (bdk_wallet 2.1.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 bdk.kt
 libbdkffi.dylib
 /.idea
+.DS_Store

--- a/justfile
+++ b/justfile
@@ -28,6 +28,14 @@ submodule-init:
 submodule-reset:
   git submodule update --force
 
+[group("Submodule")]
+[doc("Checkout the bdk-ffi submodule to the latest commit on master.")]
+submodule-to-master:
+  cd ./bdk-ffi/ \
+  && git fetch origin \
+  && git checkout master \
+  && git pull origin master
+
 [group("Build")]
 [doc("Build the library for given ARCH.")]
 build ARCH="macos-aarch64":


### PR DESCRIPTION
This is dependent on bitcoindevkit/bdk-ffi#835.

Once that's in I'll bump the submodule! Notice also the submodule command I added.