### PR TITLE
refactor: remove bdk-jvm directory navigation from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,20 +53,17 @@ bash ./scripts/build-<your-local-architecture>.sh
 The `examples` module show different samples of how some of the APIs can be used. You can run the examples after building as stated above. The gradle task to run is by convention the file name of the example file.
 
 ```shell
-cd bdk-jvm
 ./gradlew MultisigTransaction
 ```
 
 You can also list the application tasks. (All examples grouped under application)
 ```shell
-cd bdk-jvm
 ./gradlew tasks --group application
 ```
 
 ## How to publish to your local Maven repo
 
 ```shell
-cd bdk-jvm
 ./gradlew publishToMavenLocal -P localBuild
 ```
 


### PR DESCRIPTION
Given the context of this new repo, it might be confusing to have cd `bdk-jvm`. We might want to remove that. I am open to a better suggestion