### PR TITLE
Run tests only once on pull requests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,7 @@
 name: Run All Tests
 on:
-  workflow_dispatch:
-  push:
   pull_request:
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
We were running tests twice on PRs because they ran every time there was a commit pushed to the repo, but also every time there was an update to a PR.

This fixes that. One potential other thing we could do is run them one more time when commits are pushed to the default branch, but I'll leave that to another PR.